### PR TITLE
Sqldeveloper 19.1.0.094.2042 no jre

### DIFF
--- a/manual/oracle-sql-developer/oracle-sql-developer.nuspec
+++ b/manual/oracle-sql-developer/oracle-sql-developer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>oracle-sql-developer</id>
-    <version>18.4.0</version>
+    <version>19.1.0</version>
     <title>Oracle SQL Developer</title>
     <authors>Oracle</authors>
     <owners>Wayne Carson</owners>
@@ -31,14 +31,14 @@
       To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
       To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
     </description>
-    <releaseNotes>https://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/sqldev-relnotes-v184-5231669.html</releaseNotes>
+    <releaseNotes>https://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/sqldev-relnotes-191-5458711.html</releaseNotes>
     <packageSourceUrl>ttps://github.com/wcarson/chocolatey-packages/</packageSourceUrl>
     <projectUrl>https://www.oracle.com/database/technologies/appdev/sql-developer.html</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/wcarson/chocolatey-packages/master/icons/oracle-sql-developer.png</iconUrl>
     <copyright>2019 Oracle</copyright>
     <licenseUrl>http://www.oracle.com/technetwork/licenses/sqldev-license-152021.html</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <docsUrl>https://docs.oracle.com/en/database/oracle/sql-developer/18.4/index.html</docsUrl>
+    <docsUrl>https://docs.oracle.com/en/database/oracle/sql-developer/19.1/index.html</docsUrl>
     <tags>oracle sql developer ide</tags>
     <dependencies>
       <dependency id="jdk8" />

--- a/manual/oracle-sql-developer/oracle-sql-developer.nuspec
+++ b/manual/oracle-sql-developer/oracle-sql-developer.nuspec
@@ -21,6 +21,11 @@
       * An Oracle account is **required** to download this package. See the "Package Parameters" section below for
       details on how to provide your Oracle credentials to the installer. If you don't have an existing account, you can
       create one for free here: https://profile.oracle.com/myprofile/account/create-account.jspx
+      * If you get the below error when installing, then sure you run Internet Explorer at least once 
+      (for instance by calling `start iexplore` from the elevated command prompt)
+
+        > ERROR: The response content cannot be parsed because the Internet Explorer engine is not available, or Internet
+        > Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
 
       #### Package Parameters
       The following package parameters are **required**:

--- a/manual/oracle-sql-developer/tools/chocolateyinstall.ps1
+++ b/manual/oracle-sql-developer/tools/chocolateyinstall.ps1
@@ -7,10 +7,10 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $params = Get-PackageParameters
 
-$version = '18.4.0'
-$zipFileName = 'sqldeveloper-18.4.0-376.1900-no-jre.zip'
+$version = '19.1.0'
+$zipFileName = 'sqldeveloper-19.1.0.094.2042-no-jre.zip'
 $url = "https://download.oracle.com/otn/java/sqldeveloper/$zipFileName"
-$sha1hash = '2536dad95e0390f7202f0c5962a1af99ee3de787'
+$sha1hash = '2e8778b1110a15d6447afddfe48efc1a885e1410'
 $loginSubmit = 'https://login.oracle.com/oam/server/sso/auth_cred_submit'
 $proxy = Get-ChocolateyProxy $url
 

--- a/manual/oracle-sql-developer/tools/chocolateyinstall.ps1
+++ b/manual/oracle-sql-developer/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-. "$toolsDir/helpers.ps1"
-
 $packageDir = $env:ChocolateyPackageFolder
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
+
+. "$toolsDir/helpers.ps1"
 
 $params = Get-PackageParameters
 


### PR DESCRIPTION
Fixes #1 

- Updated for [Oracle SQL Developer version 19.1.0](https://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/sqldev-relnotes-191-5458711.html)
- Fix `ERROR: The term '/helpers.ps1' is not recognized`
- Explain error of `Invoke-WebRequest` failing with `ERROR: The response content cannot be parsed because the Internet Explorer engine is not available`

Note the last likely should have prevented moderator approval of the original <https://chocolatey.org/packages/oracle-sql-developer> package (see <https://gitter.im/chocolatey/choco?at=5ce7e48a75d9a575a6383fe8> and <https://gitter.im/chocolatey/choco?at=5ce7e43c879f4478c7d41460>)

Ideally, the code in https://github.com/wcarson/chocolatey-packages/blob/master/manual/oracle-sql-developer/tools/chocolateyinstall.ps1 to get `$loginPage` and `$packageArgs.url` should be written without using `Invoke-WebRequest`, but do due to care-taking issues, I not have the resources to fix that in the foreseeable future myself.

Maybe a workaround could be made using the [chocolatey package for cURL](https://chocolatey.org/packages/curl), or by using a [`System.Net.WebRequest`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webrequest?view=netframework-4.8) wrapper.

Otherwise a very good argument needs to be phrased towards moderators to accept the package as is (for instance by researching if this can ever be installed on a system having only PowerShell 2.